### PR TITLE
pass full plugin config to layers

### DIFF
--- a/sys/Plugins/PluginBuilder.php
+++ b/sys/Plugins/PluginBuilder.php
@@ -85,7 +85,7 @@ class PluginBuilder {
 		$this->plugin = new Plugin();
 
 		foreach ($this->layers as $layer) {
-			$this->plugin->{$layer->getName()} = new $config[$layer->getName()]['className']($config[$layer->getName()]);
+			$this->plugin->{$layer->getName()} = new $config[$layer->getName()]['className']($config[$layer->getName()], $config);
 		}
 
 		return $this->plugin;

--- a/sys/Plugins/Transports/HttpTransportExtended.php
+++ b/sys/Plugins/Transports/HttpTransportExtended.php
@@ -35,14 +35,15 @@ class HttpTransportExtended implements TransportInterface, BuilderLayerInterface
 	 * @var list of observed properties' conversions to variables
 	 */
 	private $observedPropertyConversions;
-
-
+	
+	
 	/**
 	 * HttpTransportExtended constructor.
 	 *
 	 * @param array $config
+	 * @param array $pluginConfig
 	 */
-	public function __construct(array $config) {
+	public function __construct(array $config, array $pluginConfig) {
 		$this->url = $config['url'];
 
 		// TODO: Make this configurable
@@ -189,8 +190,9 @@ class HttpTransportExtended implements TransportInterface, BuilderLayerInterface
 					// contains pipe symbol, decode zip
 					$ext = pathinfo($url, PATHINFO_EXTENSION);
 					$temp = tempnam(sys_get_temp_dir(), $ext);
+					
 					copy($url, $temp);
-
+					
 					$zip = new \ZipArchive;
 					$zip->open($temp);
 					$found = false;


### PR DESCRIPTION
I recommend making this change in the plugin builder, so that the layers get the full plugin configuration when they are created. Your transport could then use the info in the 'apiClient' section of that.

I would maybe just instantiate an ApiClient with that config inside the transport and implement a new method in it that gets the monitoring point data, but that is up to you.