### PR TITLE
fixed timezone conversion for XmlParser

### DIFF
--- a/sys/Plugins/Parsers/XmlParser.php
+++ b/sys/Plugins/Parsers/XmlParser.php
@@ -395,7 +395,11 @@ class XmlParser extends AbstractParser implements BuilderLayerInterface {
 		{
 			$t = mktime(strval($Hour["Value"]), strval($Minute["Value"]), 0,
 				strval($Month["Value"]), strval($Day["Value"]), strval($Year["Value"]));
-			$result["Value"] = date(self::API_TIME_FORMAT_STRING, $t);
+			$format = "dmY H:i:s";
+			$dateLocal = date($format, $t);
+			$date = DateTime::createFromFormat($format, $dateLocal, $this->getTimeZone());
+			$date->setTimezone(new DateTimeZone('UTC'));
+			$result["Value"] = $date->format(self::API_TIME_FORMAT_STRING);
 			$this->delete($entry, "Type", "Year");
 			$this->delete($entry, "Type", "Month");
 			$this->delete($entry, "Type", "Day");


### PR DESCRIPTION
fixed timezone conversion for case that year, month, day, time and hour are given separately (which is the case for LfU).
This case was did not yet do a timezone conversion.