### PR TITLE
Fix: FTP last file was skipped in list

### DIFF
--- a/sys/Plugins/Transports/FtpTransport.php
+++ b/sys/Plugins/Transports/FtpTransport.php
@@ -214,11 +214,11 @@ class FtpTransport implements TransportInterface, BuilderLayerInterface {
 
 		// Take only files which meet the filename pattern
 		$contents = [];
-		foreach ($contentsAll as $entry) {
-			if ($this->filenamePattern !== '' && !fnmatch($this->filenamePattern, $entry['name'])) {
+		foreach ($contentsAll as $entry2) {
+			if ($this->filenamePattern !== '' && !fnmatch($this->filenamePattern, $entry2['name'])) {
 				continue;
 			}
-			array_push($contents, $path . $entry['name']);
+			array_push($contents, $path . $entry2['name']);
 		}
 
 		//die(var_dump($contents));


### PR DESCRIPTION
When reading a list of files from FTP, last file was skipped. Reason was the &$entry reference reused from a previous loop.