### PR TITLE
Improve field order in forms and display page and other display improvements

### DIFF
--- a/sys/Admin/templates/hydro/monitoringpoint/form.phtml
+++ b/sys/Admin/templates/hydro/monitoringpoint/form.phtml
@@ -12,16 +12,24 @@
         </div>
 
         <div class="form-group">
-            <label for="ncd_wgst">NCD WGST</label>
+            <label for="country">Country code (ISO3166-1 ALPHA-2)</label>
+            <input type="text" name="country" id="country" maxlength="2" class="form-control <?=isFieldInvalidClass('country', get_defined_vars());?>" value="<?=formFieldValue('country', $record);?>" />
+      			<div class="invalid-feedback">
+      		        <?=getFieldInvalidMessage('country', get_defined_vars());?>
+      			</div>
+        </div>
+
+        <div class="form-group">
+            <label for="ncd_wgst">National code of the water gauge station</label>
             <input type="text" name="ncd_wgst" id="ncd_wgst" class="form-control <?=isFieldInvalidClass('ncd_wgst', get_defined_vars());?>" required value="<?=formFieldValue('ncd_wgst', $record);?>" />
             <div class="invalid-feedback">
-	            <?=getFieldInvalidMessage('ncd_wgst', get_defined_vars(), 'Please provide a valid Ncd wgst value!');?>
+	            <?=getFieldInvalidMessage('ncd_wgst', get_defined_vars(), 'Please provide a valid national code value!');?>
             </div>
         </div>
 
 		<?php if($request->getIdentity()->hasPermissions(['admin.all']) || $request->getIdentity()->hasPermissions(['admin.hydro.monitoringpoints.update'])): ?>
 			<div class="form-group">
-				<label for="eucd_wgst">EUCD WGST
+				<label for="eucd_wgst">International code of the water gauge station
 					<?php if($record) : ?>
 						<small>(Current value: <?=$record['eucd_wgst'] ?? null;?>)</small>
 					<?php endif; ?>
@@ -40,20 +48,7 @@
         <div class="form-check">
             <input type="hidden" name="is_out_of_order" value="0"/>
             <input type="checkbox" name="is_out_of_order" id="is_out_of_order" value="1" class="form-check-input" <?=formFieldValue('is_out_of_order', $record) ? 'checked' : '';?>/>
-            <label for="is_out_of_order">Is Ouf of Order</label>
-        </div>
-
-        <div class="form-group">
-            <label for="vertical_reference">Vertical reference</label>
-            <input type="text" name="vertical_reference" id="vertical_reference" class="form-control" value="<?=formFieldValue('vertical_reference', $record);?>" />
-        </div>
-
-        <div class="form-group">
-            <label for="country">Country</label>
-            <input type="text" name="country" id="country" maxlength="2" class="form-control <?=isFieldInvalidClass('country', get_defined_vars());?>" value="<?=formFieldValue('country', $record);?>" />
-			<div class="invalid-feedback">
-		        <?=getFieldInvalidMessage('country', get_defined_vars());?>
-			</div>
+            <label for="is_out_of_order">Is ouf of order</label>
         </div>
 
         <div class="form-group">
@@ -72,23 +67,48 @@
         </div>
 
         <div class="form-group">
+            <label for="gauge_zero">Gauge zero</label>
+            <input type="number" name="gauge_zero" id="gauge_zero" step="0.000001"  class="form-control" value="<?=formFieldValue('gauge_zero', $record);?>" />
+        </div>
+
+        <div class="form-group">
+            <label for="vertical_reference">Vertical reference</label>
+            <input type="text" name="vertical_reference" id="vertical_reference" class="form-control" value="<?=formFieldValue('vertical_reference', $record);?>" />
+        </div>
+
+        <div class="form-group">
             <label for="location">Location</label>
             <input type="text" name="location" id="location" class="form-control" value="<?=formFieldValue('location', $record);?>" />
         </div>
 
+        <fieldset class="form-group">
+            <legend><?=__('River');?></legend>
+    			<?php $selectedRiver = formFieldValue('river', $record); ?>
+            <div class="field">
+                <select name="river">
+					<?=selectOptions($rivers, $selectedRiver ?? null, ' - '.__('No river').' - ');?>
+                </select>
+            </div>
+        </fieldset>
+
+        <fieldset class="form-group">
+            <legend><?=__('Riverbank');?></legend>
+			<?php $selectedRiverbank = formFieldValue('riverbank', $record); ?>
+            <div class="field">
+                <select name="riverbank">
+					<?=selectOptions($riverbanks, $selectedRiverbank ?? null, ' - '.__('No riverbank').' - ');?>
+                </select>
+            </div>
+        </fieldset>
+
         <div class="form-group">
             <label for="river_kilometer">River kilometer</label>
-            <input type="number" name="river_kilometer" id="river_kilometer" step="0.000001"  class="form-control" value="<?=formFieldValue('river_kilometer', $record);?>" />
+            <input type="number" name="river_kilometer" id="river_kilometer" step="0.001"  class="form-control" value="<?=formFieldValue('river_kilometer', $record);?>" />
         </div>
 
         <div class="form-group">
-            <label for="catchment_area">Catchment area</label>
-            <input type="number" name="catchment_area" id="catchment_area" step="0.000001"  class="form-control" value="<?=formFieldValue('catchment_area', $record);?>" />
-        </div>
-
-        <div class="form-group">
-            <label for="gauge_zero">Gauge zero</label>
-            <input type="number" name="gauge_zero" id="gauge_zero" step="0.000001"  class="form-control" value="<?=formFieldValue('gauge_zero', $record);?>" />
+            <label for="catchment_area">Catchment area in km²</label>
+            <input type="number" name="catchment_area" id="catchment_area" step="0.001" min="0" class="form-control" value="<?=formFieldValue('catchment_area', $record);?>" />
         </div>
 
         <div class="form-group">
@@ -126,26 +146,6 @@
 				<div class="invalid-feedback">
 		            <?=getFieldInvalidMessage('operator', get_defined_vars());?>
 				</div>
-            </div>
-        </fieldset>
-
-        <fieldset class="form-group">
-            <legend><?=__('Riverbank');?></legend>
-			<?php $selectedRiverbank = formFieldValue('riverbank', $record); ?>
-            <div class="field">
-                <select name="riverbank">
-					<?=selectOptions($riverbanks, $selectedRiverbank ?? null, ' - '.__('No riverbank').' - ');?>
-                </select>
-            </div>
-        </fieldset>
-
-        <fieldset class="form-group">
-            <legend><?=__('River');?></legend>
-			<?php $selectedRiver = formFieldValue('river', $record); ?>
-            <div class="field">
-                <select name="river">
-					<?=selectOptions($rivers, $selectedRiver ?? null, ' - '.__('No river').' - ');?>
-                </select>
             </div>
         </fieldset>
 

--- a/sys/Admin/templates/hydro/monitoringpoint/index.phtml
+++ b/sys/Admin/templates/hydro/monitoringpoint/index.phtml
@@ -12,9 +12,10 @@
         <thead>
             <tr>
                 <th><?=sortableColumn('Name', 'name');?></th>
-                <th class="fit-content"><?=sortableColumn('Is active', 'is_active');?></th>
-                <th class="fit-content"><?=sortableColumn('Is Ouf of Order', 'is_out_of_order');?></th>
-                <th class="fit-content"><?=sortableColumn('Country', 'country');?></th>
+                <th class="fit-content"><?=sortableColumn('Active', 'is_active');?></th>
+                <th class="fit-content"><?=sortableColumn('Out of order', 'is_out_of_order');?></th>
+				        <th class="fit-content"><?=sortableColumn('Country', 'country');?></th>
+				        <th class="fit-content"><?=sortableColumn('National code', 'ncd_wgst');?></th>
                 <th><?=sortableColumn('Operator', 'operator');?></th>
                 <th class="actions">Actions</th>
             </tr>
@@ -27,8 +28,9 @@
                 <tr>
                     <td><?=$record['name'] ?? null;?></td>
                     <td class="fit-content"><i class="fa <?=$record['is_active'] ? 'fa-check text-success' : 'fa-times text-danger';?>"></i></td>
-                    <td class="fit-content"><i class="fa <?=$record['is_out_of_order'] ? 'fa-check text-success' : 'fa-times text-danger';?>"></i></td>
+                    <td class="fit-content"><i class="fa <?=$record['is_out_of_order'] ? 'fa-ban text-danger' : '';?>"></i></td>
                     <td class="fit-content"><?=$record['country'] ?? null;?></td>
+					          <td><?=$record['ncd_wgst'] ?? null;?></td>
                     <td class="text-truncate" title="<?=$record['operator'] ?? null;?>"><?=$record['operator'] ?? null;?></td>
                     <td class="actions">
                         <a href="/admin/hydro/monitoring-points/show?id=<?=$record['id'];?>"><i class="fas fa-eye text-muted"></i></a>

--- a/sys/Admin/templates/hydro/monitoringpoint/show.phtml
+++ b/sys/Admin/templates/hydro/monitoringpoint/show.phtml
@@ -11,35 +11,20 @@
         <dt class="col-sm-3">Name</dt>
         <dd class="col-sm-9"><?=$record['name'] ?? '';?></dd>
 
-        <dt class="col-sm-3">EUCD WGST</dt>
-        <dd class="col-sm-9"><?=$record['eucd_wgst'] ?? '';?></dd>
+    		<dt class="col-sm-3">Country code</dt>
+    		<dd class="col-sm-9"><?=$record['country'] ?? '';?></dd>
 
-        <dt class="col-sm-3">NCD WGST</dt>
+        <dt class="col-sm-3">National code of the water gauge station</dt>
         <dd class="col-sm-9"><?=$record['ncd_wgst'] ?? '';?></dd>
 
-		<dt class="col-sm-3">Operator</dt>
-		<dd class="col-sm-9">
-		    <?php if(!empty($record['operator'])): ?>
-				<a href="/admin/operators/show?id=<?= $record['operator']['id'] ;?>">#<?= $record['operator']['id'] ?></a>
-				<span><?=$record['operator']['name'] ?? null;?></span>
-		    <?php endif; ?>
-		</dd>
+        <dt class="col-sm-3">International code of the water gauge station</dt>
+        <dd class="col-sm-9"><?=$record['eucd_wgst'] ?? '';?></dd>
 
-		<dt class="col-sm-3">River</dt>
-		<dd class="col-sm-9">
-		    <?php if(!empty($record['river'])): ?>
-				<a href="/admin/hydro/rivers/show?id=<?= $record['river']['eucd_riv'] ;?>">#<?= $record['river']['eucd_riv'] ?></a>
-		    <?php endif; ?>
-		</dd>
+        <dt class="col-sm-3">Is active</dt>
+        <dd class="col-sm-9"><?=$record['is_active'] ? 'Yes' : 'No';?></dd>
 
-		<dt class="col-sm-3">Country</dt>
-		<dd class="col-sm-9"><?=$record['country'] ?? '';?></dd>
-
-		<dt class="col-sm-3">Location</dt>
-		<dd class="col-sm-9"><?=$record['location'] ?? '';?></dd>
-
-		<dt class="col-sm-3">River basin</dt>
-		<dd class="col-sm-9"><?=$record['river_basin'] ?? '';?></dd>
+        <dt class="col-sm-3">Is out of order</dt>
+        <dd class="col-sm-9"><?=$record['is_out_of_order'] ? 'Yes' : 'No';?></dd>
 
         <dt class="col-sm-3">Latitude coordinate</dt>
         <dd class="col-sm-9"><?=$record['lat'] ?? '';?></dd>
@@ -49,12 +34,38 @@
 
         <dt class="col-sm-3">Z coordinate</dt>
         <dd class="col-sm-9"><?=$record['z'] ?? '';?></dd>
-
+<!-- Not editable, not used:
         <dt class="col-sm-3">Map Latitude coordinate</dt>
         <dd class="col-sm-9"><?=$record['maplat'] ?? '';?></dd>
 
         <dt class="col-sm-3">Map Longitude coordinate</dt>
         <dd class="col-sm-9"><?=$record['maplong'] ?? '';?></dd>
+
+        <dt class="col-sm-3">UTC Offset</dt>
+        <dd class="col-sm-9"><?=$record['utc_offset'] ?? '';?></dd>
+-->
+        <dt class="col-sm-3">Gauge zero</dt>
+        <dd class="col-sm-9"><?=$record['gauge_zero'] ?? '';?></dd>
+
+        <dt class="col-sm-3">Vertical reference</dt>
+        <dd class="col-sm-9"><?=$record['vertical_reference'] ?? '';?></dd>
+
+    		<dt class="col-sm-3">Location</dt>
+    		<dd class="col-sm-9"><?=$record['location'] ?? '';?></dd>
+
+    		<dt class="col-sm-3">River</dt>
+    		<dd class="col-sm-9">
+    		    <?php if(!empty($record['river'])): ?>
+    				<a href="/admin/hydro/rivers/show?id=<?= $record['river']['eucd_riv'] ;?>">#<?= $record['river']['eucd_riv'] ?></a>
+    		    <?php endif; ?>
+    		</dd>
+
+        <dt class="col-sm-3">Riverbank</dt>
+        <dd class="col-sm-9">
+			<?php if(!empty($record['riverbank'])): ?>
+                <span><?=$record['riverbank']['value'] ?? null;?></span>
+			<?php endif; ?>
+        </dd>
 
         <dt class="col-sm-3">River kilometer</dt>
         <dd class="col-sm-9"><?=$record['river_kilometer'] ?? '';?></dd>
@@ -62,20 +73,14 @@
         <dt class="col-sm-3">Catchment area</dt>
         <dd class="col-sm-9"><?=$record['catchment_area'] ?? '';?></dd>
 
-        <dt class="col-sm-3">Gauge zero</dt>
-        <dd class="col-sm-9"><?=$record['gauge_zero'] ?? '';?></dd>
+    		<dt class="col-sm-3">River basin</dt>
+    		<dd class="col-sm-9"><?=$record['river_basin'] ?? '';?></dd>
 
         <dt class="col-sm-3">Start time</dt>
         <dd class="col-sm-9"><?=$record['start_time'] ?? '';?></dd>
 
         <dt class="col-sm-3">End time</dt>
         <dd class="col-sm-9"><?=$record['end_time'] ?? '';?></dd>
-
-        <dt class="col-sm-3">UTC Offset</dt>
-        <dd class="col-sm-9"><?=$record['utc_offset'] ?? '';?></dd>
-
-        <dt class="col-sm-3">Vertical reference</dt>
-        <dd class="col-sm-9"><?=$record['vertical_reference'] ?? '';?></dd>
 
         <dt class="col-sm-3">Station classification</dt>
         <dd class="col-sm-9">
@@ -85,19 +90,20 @@
             <?php endif; ?>
         </dd>
 
-        <dt class="col-sm-3">Riverbank</dt>
-        <dd class="col-sm-9">
-			<?php if(!empty($record['riverbank'])): ?>
-                <span><?=$record['riverbank']['value'] ?? null;?></span>
-			<?php endif; ?>
-        </dd>
+    		<dt class="col-sm-3">Operator</dt>
+    		<dd class="col-sm-9">
+    		    <?php if(!empty($record['operator'])): ?>
+    				<a href="/admin/operators/show?id=<?= $record['operator']['id'] ;?>">#<?= $record['operator']['id'] ?></a>
+    				<span><?=$record['operator']['name'] ?? null;?></span>
+    		    <?php endif; ?>
+    		</dd>
 
-		<dt class="col-sm-3">Observerd properties</dt>
-		<dd class="col-sm-9">
-		    <?php foreach ($record['showObservedProperty'] ?: [] as $property) { ?>
-				<a href="/admin/hydro/observed-properties/edit?id=<?=$property['id'];?>">#<?=$property['symbol'] ?? null;?></a><br>
-		    <?php } ?>
-		</dd>
+    		<dt class="col-sm-3">Observerd properties</dt>
+    		<dd class="col-sm-9">
+    		    <?php foreach ($record['showObservedProperty'] ?: [] as $property) { ?>
+    				<a href="/admin/hydro/observed-properties/edit?id=<?=$property['id'];?>">#<?=$property['symbol'] ?? null;?></a><br>
+    		    <?php } ?>
+    		</dd>
     </dl>
 </div>
 <?php include __DIR__ . '../../../layouts/after_app.phtml'; ?>

--- a/sys/Admin/templates/hydro/river/form.phtml
+++ b/sys/Admin/templates/hydro/river/form.phtml
@@ -5,7 +5,7 @@
 		<input type="hidden" name="__csrf" value="<?=$csrf;?>"/>
 		<?php if ( is_null($record) ): ?>
         <div class="form-group">
-            <label for="eucd_riv">EUCD RIV</label>
+            <label for="eucd_riv">International code of the river</label>
             <input type="text" name="eucd_riv" id="eucd_riv" class="form-control <?=isFieldInvalidClass('eucd_riv', get_defined_vars());?>"  value="<?=formFieldValue('eucd_riv', $record);?>" />
 			<div class="invalid-feedback">
 		        <?=getFieldInvalidMessage('eucd_riv', get_defined_vars());?>
@@ -13,7 +13,7 @@
         </div>
 		<?php endif; ?>
         <div class="form-group">
-            <label for="cname">Cname</label>
+            <label for="cname">Name</label>
             <input type="text" name="cname" id="cname" class="form-control <?=isFieldInvalidClass('cname', get_defined_vars());?>"  value="<?=formFieldValue('cname', $record);?>" />
 			<div class="invalid-feedback">
 		        <?=getFieldInvalidMessage('cname', get_defined_vars());?>

--- a/sys/Admin/templates/hydro/river/show.phtml
+++ b/sys/Admin/templates/hydro/river/show.phtml
@@ -5,9 +5,9 @@
 	]);?>
 
 	<dl class="row">
-        <dt class="col-sm-5">EUCD RIV</dt>
+        <dt class="col-sm-5">International code of the river</dt>
         <dd class="col-sm-7"><?=$record['eucd_riv'] ?? '';?></dd>
-        <dt class="col-sm-5">Cname</dt>
+        <dt class="col-sm-5">Name</dt>
         <dd class="col-sm-7"><?=$record['cname'] ?? '';?></dd>
 
     </dl>

--- a/sys/Admin/templates/meteo/monitoringpoint/form.phtml
+++ b/sys/Admin/templates/meteo/monitoringpoint/form.phtml
@@ -6,22 +6,30 @@
         <div class="form-group">
             <label for="name">Name</label>
             <input type="text" name="name" id="name" class="form-control <?=isFieldInvalidClass('name', get_defined_vars());?>" required value="<?=formFieldValue('name', $record);?>" />
-			<div class="invalid-feedback">
-		        <?=getFieldInvalidMessage('name', get_defined_vars(), 'Please provide a valid name!');?>
-			</div>
+      			<div class="invalid-feedback">
+      		        <?=getFieldInvalidMessage('name', get_defined_vars(), 'Please provide a valid name!');?>
+      			</div>
         </div>
 
         <div class="form-group">
-            <label for="ncd_pst">NCD PST</label>
+            <label for="country">Country code (ISO3166-1 ALPHA-2)</label>
+            <input type="text" name="country" id="country" maxlength="2" class="form-control <?=isFieldInvalidClass('country', get_defined_vars());?>" value="<?=formFieldValue('country', $record);?>" />
+      			<div class="invalid-feedback">
+      		        <?=getFieldInvalidMessage('country', get_defined_vars());?>
+      			</div>
+    		</div>
+
+        <div class="form-group">
+            <label for="ncd_pst">National code of the meteorological station</label>
             <input type="text" name="ncd_pst" id="ncd_pst" class="form-control <?=isFieldInvalidClass('ncd_pst', get_defined_vars());?>" required value="<?=formFieldValue('ncd_pst', $record);?>" />
-			<div class="invalid-feedback">
-		        <?=getFieldInvalidMessage('ncd_pst', get_defined_vars(), 'Please provide a valid Ncd pst value!');?>
-			</div>
+      			<div class="invalid-feedback">
+      		        <?=getFieldInvalidMessage('ncd_pst', get_defined_vars(), 'Please provide a valid national code value!');?>
+      			</div>
         </div>
 
 		<?php if($request->getIdentity()->hasPermissions(['admin.all']) || $request->getIdentity()->hasPermissions(['admin.meteo.monitoringpoints.update'])): ?>
 			<div class="form-group">
-				<label for="eucd_pst">EUCD PST
+				<label for="eucd_pst">International code of the meteorological station
 					<?php if($record) : ?>
 						<small>(Current value: <?=$record['eucd_pst'] ?? null;?>)</small>
 					<?php endif; ?>
@@ -40,21 +48,8 @@
         <div class="form-check">
             <input type="hidden" name="is_out_of_order" value="0"/>
             <input type="checkbox" name="is_out_of_order" id="is_out_of_order" value="1" class="form-check-input" <?=formFieldValue('is_out_of_order', $record) ? 'checked' : '';?>/>
-            <label for="is_out_of_order">Is Ouf of Order</label>
+            <label for="is_out_of_order">Is ouf of order</label>
         </div>
-
-        <div class="form-group">
-            <label for="vertical_reference">Vertical reference</label>
-            <input type="text" name="vertical_reference" id="vertical_reference" class="form-control" value="<?=formFieldValue('vertical_reference', $record);?>" />
-        </div>
-
-        <div class="form-group">
-            <label for="country">Country</label>
-            <input type="text" name="country" id="country" maxlength="2" class="form-control <?=isFieldInvalidClass('country', get_defined_vars());?>" value="<?=formFieldValue('country', $record);?>" />
-			<div class="invalid-feedback">
-		        <?=getFieldInvalidMessage('country', get_defined_vars());?>
-			</div>
-		</div>
 
         <div class="form-group">
             <label for="lat">Latitude coordinate</label>
@@ -74,6 +69,11 @@
         <div class="form-group">
             <label for="altitude">Altitude</label>
             <input type="number" name="altitude" id="altitude" step="0.000001" class="form-control" value="<?=formFieldValue('altitude', $record);?>" />
+        </div>
+
+        <div class="form-group">
+            <label for="vertical_reference">Vertical reference</label>
+            <input type="text" name="vertical_reference" id="vertical_reference" class="form-control" value="<?=formFieldValue('vertical_reference', $record);?>" />
         </div>
 
         <div class="form-group">

--- a/sys/Admin/templates/meteo/monitoringpoint/index.phtml
+++ b/sys/Admin/templates/meteo/monitoringpoint/index.phtml
@@ -12,9 +12,10 @@
         <thead>
             <tr>
                 <th><?=sortableColumn('Name', 'name');?></th>
-				<th class="fit-content"><?=sortableColumn('Is active', 'is_active');?></th>
-                <th class="fit-content"><?=sortableColumn('Is Ouf of Order', 'is_out_of_order');?></th>
-				<th class="fit-content"><?=sortableColumn('Country', 'country');?></th>
+        				<th class="fit-content"><?=sortableColumn('Active', 'is_active');?></th>
+                <th class="fit-content"><?=sortableColumn('Out of order', 'is_out_of_order');?></th>
+				        <th class="fit-content"><?=sortableColumn('Country', 'country');?></th>
+				        <th class="fit-content"><?=sortableColumn('National code', 'ncd_pst');?></th>
                 <th><?=sortableColumn('Operator', 'operator');?></th>
                 <th class="actions">Actions</th>
             </tr>
@@ -26,9 +27,10 @@
 			?>
                 <tr>
                     <td><?=$record['name'] ?? null;?></td>
-					<td class="fit-content"><i class="fa <?=$record['is_active'] ? 'fa-check text-success' : 'fa-times text-danger';?>"></i></td>
-                    <td class="fit-content"><i class="fa <?=$record['is_out_of_order'] ? 'fa-check text-success' : 'fa-times text-danger';?>"></i></td>
-					<td class="fit-content"><?=$record['country'] ?? null;?></td>
+					          <td class="fit-content"><i class="fa <?=$record['is_active'] ? 'fa-check text-success' : 'fa-times text-danger';?>"></i></td>
+                    <td class="fit-content"><i class="fa <?=$record['is_out_of_order'] ? 'fa-ban text-danger' : '';?>"></i></td>
+					          <td class="fit-content"><?=$record['country'] ?? null;?></td>
+					          <td><?=$record['ncd_pst'] ?? null;?></td>
                     <td class="text-truncate" title="<?=$record['operator'] ?? null;?>"><?=$record['operator'] ?? null;?></td>
                     <td class="actions">
                         <a href="/admin/meteo/monitoring-points/show?id=<?=$record['id'];?>"><i class="fas fa-eye text-muted"></i></a>

--- a/sys/Admin/templates/meteo/monitoringpoint/show.phtml
+++ b/sys/Admin/templates/meteo/monitoringpoint/show.phtml
@@ -11,28 +11,20 @@
         <dt class="col-sm-3">Name</dt>
         <dd class="col-sm-9"><?=$record['name'] ?? '';?></dd>
 
-        <dt class="col-sm-3">EUCD PSD</dt>
-        <dd class="col-sm-9"><?=$record['eucd_pst'] ?? '';?></dd>
+    		<dt class="col-sm-3">Country code</dt>
+    		<dd class="col-sm-9"><?=$record['country'] ?? '';?></dd>
 
-        <dt class="col-sm-3">NCD PST</dt>
+        <dt class="col-sm-3">National code of the meteorological station</dt>
         <dd class="col-sm-9"><?=$record['ncd_pst'] ?? '';?></dd>
 
-		<dt class="col-sm-3">Operator</dt>
-		<dd class="col-sm-9">
-		    <?php if(!empty($record['operator'])): ?>
-				<a href="/admin/operators/show?id=<?= $record['operator']['id'] ;?>">#<?= $record['operator']['id'] ?></a>
-				<span><?=$record['operator']['name'] ?? null;?></span>
-		    <?php endif; ?>
-		</dd>
+        <dt class="col-sm-3">International code of the meteorological station</dt>
+        <dd class="col-sm-9"><?=$record['eucd_pst'] ?? '';?></dd>
 
-		<dt class="col-sm-3">Country</dt>
-		<dd class="col-sm-9"><?=$record['country'] ?? '';?></dd>
+        <dt class="col-sm-3">Is active</dt>
+        <dd class="col-sm-9"><?=$record['is_active'] ? 'Yes' : 'No';?></dd>
 
-		<dt class="col-sm-3">Location</dt>
-		<dd class="col-sm-9"><?=$record['location'] ?? '';?></dd>
-
-		<dt class="col-sm-3">River basin</dt>
-		<dd class="col-sm-9"><?=$record['river_basin'] ?? '';?></dd>
+        <dt class="col-sm-3">Is out of order</dt>
+        <dd class="col-sm-9"><?=$record['is_out_of_order'] ? 'Yes' : 'No';?></dd>
 
         <dt class="col-sm-3">Latitude coordinate</dt>
         <dd class="col-sm-9"><?=$record['lat'] ?? '';?></dd>
@@ -43,26 +35,34 @@
         <dt class="col-sm-3">Z coordinate</dt>
         <dd class="col-sm-9"><?=$record['z'] ?? '';?></dd>
 
-        <dt class="col-sm-3">Altitude</dt>
-        <dd class="col-sm-9"><?=$record['altitude'] ?? '';?></dd>
-
+<!-- Not editable, not used:
         <dt class="col-sm-3">Map Latitude coordinate</dt>
         <dd class="col-sm-9"><?=$record['maplat'] ?? '';?></dd>
 
         <dt class="col-sm-3">Map Longitude coordinate</dt>
         <dd class="col-sm-9"><?=$record['maplong'] ?? '';?></dd>
 
+        <dt class="col-sm-3">UTC Offset</dt>
+        <dd class="col-sm-9"><?=$record['utc_offset'] ?? '';?></dd>
+
+-->
+        <dt class="col-sm-3">Altitude</dt>
+        <dd class="col-sm-9"><?=$record['altitude'] ?? '';?></dd>
+
+        <dt class="col-sm-3">Vertical reference</dt>
+        <dd class="col-sm-9"><?=$record['vertical_reference'] ?? '';?></dd>
+
+    		<dt class="col-sm-3">Location</dt>
+    		<dd class="col-sm-9"><?=$record['location'] ?? '';?></dd>
+
+    		<dt class="col-sm-3">River basin</dt>
+    		<dd class="col-sm-9"><?=$record['river_basin'] ?? '';?></dd>
+
         <dt class="col-sm-3">Start time</dt>
         <dd class="col-sm-9"><?=$record['start_time'] ?? '';?></dd>
 
         <dt class="col-sm-3">End time</dt>
         <dd class="col-sm-9"><?=$record['end_time'] ?? '';?></dd>
-
-        <dt class="col-sm-3">UTC Offset</dt>
-        <dd class="col-sm-9"><?=$record['utc_offset'] ?? '';?></dd>
-
-        <dt class="col-sm-3">Vertical reference</dt>
-        <dd class="col-sm-9"><?=$record['vertical_reference'] ?? '';?></dd>
 
         <dt class="col-sm-3">Station classification</dt>
         <dd class="col-sm-9">
@@ -72,12 +72,20 @@
             <?php endif; ?>
         </dd>
 
-		<dt class="col-sm-3">Observerd properties</dt>
-		<dd class="col-sm-9">
-			<?php foreach ($record['showObservedProperty'] ?: [] as $property) { ?>
-				<a href="/admin/meteo/observed-properties/edit?id=<?=$property['id'];?>">#<?=$property['symbol'] ?? null;?></a><br>
-			<?php } ?>
-		</dd>
+    		<dt class="col-sm-3">Operator</dt>
+    		<dd class="col-sm-9">
+    		    <?php if(!empty($record['operator'])): ?>
+    				<a href="/admin/operators/show?id=<?= $record['operator']['id'] ;?>">#<?= $record['operator']['id'] ?></a>
+    				<span><?=$record['operator']['name'] ?? null;?></span>
+    		    <?php endif; ?>
+    		</dd>
+
+    		<dt class="col-sm-3">Observerd properties</dt>
+    		<dd class="col-sm-9">
+    			<?php foreach ($record['showObservedProperty'] ?: [] as $property) { ?>
+    				<a href="/admin/meteo/observed-properties/edit?id=<?=$property['id'];?>">#<?=$property['symbol'] ?? null;?></a><br>
+    			<?php } ?>
+    		</dd>
     </dl>
 </div>
 <?php include __DIR__ . '../../../layouts/after_app.phtml'; ?>

--- a/sys/General/common.inc.php
+++ b/sys/General/common.inc.php
@@ -23,7 +23,7 @@ defined('REGEX_EMAIL') || define('REGEX_EMAIL', '/^((?!\.)[\w\-_.\+]*[^.])(@\w+)
 defined('REGEX_ALPHANUMERIC') || define('REGEX_ALPHANUMERIC', '/[a-zA-Z0-9_-]/i');
 defined('REGEX_USERNAME') || define('REGEX_USERNAME', REGEX_ALPHANUMERIC);
 defined('REGEX_URL') || define('REGEX_URL', '/^(?:http(s)?:\/\/)?[\w.\-]+(?:\.[\w\.\-]+)+[\w\-\._~:\/?#[\]@!\$&\'\(\)\*\+,;=.]+$/i');
-defined('REGEX_RIVERCODE') || define('REGEX_RIVERCODE', '/^[a-zA-Z_-]*$/i');
+defined('REGEX_RIVERCODE') || define('REGEX_RIVERCODE', '/^[a-zA-Z0-9 _.-]*$/i');
 
 
 /**


### PR DESCRIPTION
This commit orders the fields of monitoring points in the forms and display page in a more logic way than before. Unfortunately, moving of code is not well followed by Git diff.
Additionally, some labels are changed to be more descriptive.
Missing fields (is_active and is_out_of_order) are added to the display page.
Not editable and not used fields (maplat, maplon, utc_offset) are commented out on the display page.
Input field step value of river_kilometer and catchment_area is reduced.
Input field min value for catchment_area set to 0 to avoid negative values.
List pages: added national code and improved "out of order" icon.